### PR TITLE
Custom 'Scene Headings' and litle error

### DIFF
--- a/operators/insert.py
+++ b/operators/insert.py
@@ -41,7 +41,10 @@ Copyright: (c) 2019 Name of author
 
         """)
         bpy.data.texts[filepath].write(txt)
-        bpy.ops.scene.preview_fountain()
+        try:
+            bpy.ops.scene.preview_fountain()
+		except:
+		    pass
         bpy.data.texts[filepath].select_set(1, 1, 1, 1)
         return {"FINISHED"}
 
@@ -79,10 +82,9 @@ class SCREENWRITER_OT_insert_scene_numbers(bpy.types.Operator):
             line = line.lstrip()
             full_strip = line.strip()
             if (
+                line[0:1].upper() in ['.'] or
                 line[0:4].upper() in
-                ['INT ', 'INT.', 'EXT ', 'EXT.', 'EST ', 'EST.', 'I/E ', 'I/E.'] or
-                line[0:8].upper() in ['INT/EXT ', 'INT/EXT.'] or
-                line[0:9].upper() in ['INT./EXT ', 'INT./EXT.']
+                ['INT ', 'INT.', 'EXT ', 'EXT.', 'EST ', 'EST.', 'I/E ', 'I/E.']
             ):
                 # remove exstisting scene numbers
                 if full_strip[-1] == '#' and full_strip.count('#') > 1:

--- a/operators/insert.py
+++ b/operators/insert.py
@@ -100,9 +100,7 @@ class SCREENWRITER_OT_insert_scene_numbers(bpy.types.Operator):
                     else:
                         scene_nr +=1
                         take_nr = 0
-                    new_body = new_body + org_line + " #"+str(scene_nr)+('.'+str(take_nr),'')[take_nr==0]+"#" + "\n"
-                    if (line[0:1] != "."):
-                        take_nr  = 0
+                    new_body = new_body + org_line + " #"+str(scene_nr)+(chr(64+take_nr),'')[take_nr==0]+"#" + "\n"
             else:
                 new_body = new_body + org_line + "\n"
 

--- a/operators/insert.py
+++ b/operators/insert.py
@@ -73,7 +73,8 @@ class SCREENWRITER_OT_insert_scene_numbers(bpy.types.Operator):
         if filepath.strip() == "": return {"CANCELLED"}
 
         script_body = bpy.data.texts[filepath].as_string()
-        scene_nr = 1
+        scene_nr = 0
+        take_nr = 0
         new_body = ""
         lines = str(script_body).splitlines()
         prev_line = bpy.data.texts[filepath].current_line_index
@@ -82,8 +83,8 @@ class SCREENWRITER_OT_insert_scene_numbers(bpy.types.Operator):
             line = line.lstrip()
             full_strip = line.strip()
             if (
-                line[0:1].upper() in ['.'] or
-                line[0:4].upper() in
+                line[0:1] in ['.'] or
+				line[0:4].upper() in
                 ['INT ', 'INT.', 'EXT ', 'EXT.', 'EST ', 'EST.', 'I/E ', 'I/E.']
             ):
                 # remove exstisting scene numbers
@@ -94,8 +95,14 @@ class SCREENWRITER_OT_insert_scene_numbers(bpy.types.Operator):
                     new_body = new_body + no_number
                 # insert scene numbers
                 else:
-                    new_body = new_body + org_line + " #"+str(scene_nr)+"#" + "\n"
-                    scene_nr +=1
+                    if (line[0:1] == "."):
+                        take_nr += 1
+                    else:
+                        scene_nr +=1
+                        take_nr = 0
+                    new_body = new_body + org_line + " #"+str(scene_nr)+('.'+str(take_nr),'')[take_nr==0]+"#" + "\n"
+                    if (line[0:1] != "."):
+                        take_nr  = 0
             else:
                 new_body = new_body + org_line + "\n"
 


### PR DESCRIPTION
Scene and Take For example:

~~~
.INT
...
.SNIPER SCOPE POV
~~~
https://fountain.io/syntax#section-slug

~~~
.INT #1#
...
.SNIPER SCOPE POV #1A#
~~~

These comparisons are over, because you already take them in the first attempt with 4 characters

~~~
line[0:8].upper() in ['INT/EXT ', 'INT/EXT.'] or
line[0:9].upper() in ['INT./EXT ', 'INT./EXT.']
~~~

